### PR TITLE
Port to WebExtensions API

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,0 +1,28 @@
+var anchor_url = '';
+
+browser.contextMenus.create({
+    "id": "copy-with-ref",
+    "title": "",
+    "visible": false,
+    "contexts": ["image", "link", "page"],
+    "onclick": (info, tab) => {
+        navigator.clipboard.writeText(anchor_url)
+    }
+});
+
+browser.runtime.onMessage.addListener(async function (message) {
+    if (message.cmd == "hide") {
+        //~ console.log("Hiding menu");
+        browser.contextMenus.update("copy-with-ref", {visible: false});
+        browser.contextMenus.refresh();
+    }
+    else if (message.cmd == "show") {
+        anchor_url = message.url;
+        var fragment = message.anchor.substr(0, 20) + (message.anchor.length > 20 ? '…' : '');
+        browser.contextMenus.update("copy-with-ref", {
+            title: 'Copy anchor link #' + fragment,
+            visible: true,
+        });
+        browser.contextMenus.refresh();
+    }
+});

--- a/content.js
+++ b/content.js
@@ -22,7 +22,7 @@ function install_right_click_handler(el, anchor) {
 
 // Install contextMenu handler on elements with `id` attribute
 for (const el of document.querySelectorAll(`
-         h1[id], h2[id], h3[id], h4[id], h5[id], h6[id], 
+         h1[id], h2[id], h3[id], h4[id], h5[id], h6[id],
          p[id], span[id], blockquote[id], a[id], img[id],
          ul[id], ol[id], dl[id], li[id], dt[id],
          section[id], article[id], aside[id], figure[id], nav[id]`)) {
@@ -35,9 +35,17 @@ for (const el of document.querySelectorAll('a[name] + *')) {
     while (a && !a.name) a = a.previousSibling;  // skip empty/text nodes
     install_right_click_handler(el, a.name);
 }
+for (const el of document.querySelectorAll('a[id] + *')) {
+    var a = el.previousSibling;
+    while (a && !a.name) a = a.previousSibling;  // skip empty/text nodes
+    install_right_click_handler(el, a.id);
+}
 
 // Install contextMenu handler on elements containing an `<a name=...>` tag
 // Install handlers in reverse so the first one actually executes last
 for (const el of Array.from(document.querySelectorAll('a[name]'))) {
     install_right_click_handler(el.parentNode, el.name);
+}
+for (const el of Array.from(document.querySelectorAll('a[id]'))) {
+    install_right_click_handler(el.parentNode, el.id);
 }

--- a/content.js
+++ b/content.js
@@ -1,67 +1,23 @@
+document.body.addEventListener('mousedown', (event) => {
+    if (event.button != 2)
+        return;
+    browser.runtime.sendMessage({cmd: "hide"});
+}, false);
 
-// Appends a global <menu> to <body>, and sets body.contextmenu to its id.
-// This type of context menu only works in Firefox.
-// https://developer.mozilla.org/en-US/docs/Web/HTML/Element/menu#Browser_compatibility
-// But at least it's a normal, scriptable menu and not the useless
-// WebExtensions abomination!
-const menuitem = document.createElement('menuitem');
-
-(function buildContextMenu() {
-    const menu = document.createElement('menu');
-    menu.id = '__copy_menu__';
-    menu.type = 'context';
-    menu.appendChild(menuitem);
-    document.body.appendChild(menu);
-})();
-
-// When our menuitem selected, copy anchored link by constructing a hidden,
-// selected <input> element and temporarily inserting it into the DOM.
-menuitem.addEventListener('click', function copyLocation(event) {
-    var doc = document.createDocumentFragment(),
-        input = document.createElement('input');
-    input.style.zIndex = '-999 !important';
-    input.value += window.location.href.split('#')[0] + '#' + menuitem.dataset.anchor;
-    doc.appendChild(input);
-    document.body.appendChild(doc);
-
-    input.select();
-    document.execCommand('copy');
-
-    document.body.removeChild(input);
-    event.preventDefault();
-});
-
-var prev_element;
-
-function _updateContextMenu(element, anchor) {
-    prev_element && prev_element.removeAttribute('contextmenu');
-    (prev_element = element).setAttribute('contextmenu', '__copy_menu__');
-    menuitem.dataset.anchor = anchor;
-    menuitem.label = 'Copy anchor link #' + anchor.substr(0, 20) + (anchor.length > 20 ? '…' : '');
-}
-
-// Makes browser handle the inner-most event target last, setting
-// the menuitems' attributes to its values, not to the values of
-// some outer DOM node.
-var USE_CAPTURE = true;
-
-// Install contextMenu handler on elements that follow an `<a name=...>` tag
-for (const el of document.querySelectorAll('a[name] + *')) {
-    el.addEventListener('contextmenu', function aNameSiblingContextMenu(event) {
-        var a = event.currentTarget.previousSibling;
-        while (a && !a.name) a = a.previousSibling;  // skip empty/text nodes
-        _updateContextMenu(event.currentTarget, a.name);
-    }, USE_CAPTURE);
-}
-
-// Install contextMenu handler on elements containing an `<a name=...>` tag
-// Install handlers in reverse so the first one actually executes last
-for (const el of Array.from(document.querySelectorAll('a[name]')).reverse()) {
-    el.parentNode.addEventListener('contextmenu', (function(anchor) {
-        return function aNameBlockContextMenu(event) {
-            _updateContextMenu(event.currentTarget, anchor);
-        }
-    })(el.name), USE_CAPTURE);
+function install_right_click_handler(el, anchor) {
+    el.addEventListener('mousedown', (event) => {
+            if (event.button != 2)
+                return;
+            event.stopImmediatePropagation();
+            browser.runtime.sendMessage({
+                cmd: "show",
+                anchor: anchor,
+                url: window.location.href.split('#')[0] + '#' + anchor,
+            });
+        },
+        // Use_capture=false so we process inner-most first
+        false
+    );
 }
 
 // Install contextMenu handler on elements with `id` attribute
@@ -70,7 +26,18 @@ for (const el of document.querySelectorAll(`
          p[id], span[id], blockquote[id], a[id], img[id],
          ul[id], ol[id], dl[id], li[id], dt[id],
          section[id], article[id], aside[id], figure[id], nav[id]`)) {
-    el.addEventListener('contextmenu', function idContextMenu(event) {
-        _updateContextMenu(event.currentTarget, event.currentTarget.id);
-    }, USE_CAPTURE);
+    install_right_click_handler(el, el.id);
+}
+
+// Install contextMenu handler on elements that follow an `<a name=...>` tag
+for (const el of document.querySelectorAll('a[name] + *')) {
+    var a = el.previousSibling;
+    while (a && !a.name) a = a.previousSibling;  // skip empty/text nodes
+    install_right_click_handler(el, a.name);
+}
+
+// Install contextMenu handler on elements containing an `<a name=...>` tag
+// Install handlers in reverse so the first one actually executes last
+for (const el of Array.from(document.querySelectorAll('a[name]'))) {
+    install_right_click_handler(el.parentNode, el.name);
 }

--- a/manifest.json
+++ b/manifest.json
@@ -9,10 +9,14 @@
   "author": "Alexander Belyaev",
   "homepage_url": "https://github.com/certainlyakey/Copy-current-page-URL-with-anchor",
 
+  "background": {
+    "scripts": ["background.js"]
+  },
   "content_scripts": [
     {
       "matches": ["<all_urls>"],
       "js": ["content.js"]
     }
-  ]
+  ],
+  "permissions": ["contextMenus", "clipboardWrite"]
 }


### PR DESCRIPTION
Fixes https://github.com/certainlyakey/Copy-current-page-URL-with-anchor/issues/4

Seems to work. :grin: 

It can be tested by loading the checked out manifest.json at `about:debugging#/runtime/this-firefox`.